### PR TITLE
fix: fix skipping release pr checks

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   validate-pr-title:
-    if: "!contains(github.event.pull_request.labels.*.name, 'autorelease: tagged')"
+    if: ${{ !contains(join(github.event.pull_request.labels.*.name, ','), 'autorelease') }}
     name: pr commit
     runs-on: ubuntu-latest
     steps:
@@ -38,7 +38,7 @@ jobs:
           max_length: 60
 
   run-tflint:
-    if: "!contains(github.event.pull_request.labels.*.name, 'autorelease: tagged')"
+    if: ${{ !contains(join(github.event.pull_request.labels.*.name, ','), 'autorelease') }}
     name: linting
     runs-on: ubuntu-latest
     steps:
@@ -68,7 +68,7 @@ jobs:
         continue-on-error: false
 
   tests:
-    if: "!contains(github.event.pull_request.labels.*.name, 'autorelease: tagged')"
+    if: ${{ !contains(join(github.event.pull_request.labels.*.name, ','), 'autorelease') }}
     name: global tests
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have made corresponding changes to the documentation
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Change Log

Below please provide what should go into the changelog (if anything) 

<!-- Replace the changelog example below with your entry. One resource per line. -->

 * `azurerm_resource` - support for the `example` property


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #0000
