### PR TITLE
fix: add switch statement and fix literal access to remove linting warnings

### DIFF
--- a/tests/global_test.go
+++ b/tests/global_test.go
@@ -704,7 +704,7 @@ func extractText(node ast.Node) string {
 			case *ast.Text:
 				sb.Write(tn.Literal)
 			case *ast.Code:
-				sb.Write(tn.Leaf.Literal)
+				sb.Write(tn.Literal)
 			}
 		}
 		return ast.GoToNext
@@ -838,9 +838,11 @@ func extractFromFilePath(filePath string) ([]string, []string, error) {
 			resourceType := strings.TrimSpace(block.Labels[0])
 			resourceName := strings.TrimSpace(block.Labels[1])
 			fullResourceName := resourceType + "." + resourceName
-			if block.Type == "resource" {
+
+			switch block.Type {
+			case "resource":
 				resources = append(resources, fullResourceName)
-			} else if block.Type == "data" {
+			case "data":
 				dataSources = append(dataSources, fullResourceName)
 			}
 		}


### PR DESCRIPTION
## Description

This PR removes the below go linting warnings

```
   └╴  global_test.go  2 
     ├╴󰉉  could use tagged switch on block.Type QF1003 (default) [841, 4]
     └╴󰈧  could remove embedded field "Leaf" from selector QF1008 (default) [707, 17
```

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)