### PR TITLE
fix: replace interface with any in formatError function

### DIFF
--- a/tests/markdown_test.go
+++ b/tests/markdown_test.go
@@ -456,25 +456,10 @@ func compareHeaders(expected, actual string) error {
 	return nil
 }
 
-// formatError formats an error message
-func formatError(format string, args ...interface{}) error {
+func formatError(format string, args ...any) error {
 	return fmt.Errorf(format, args...)
 }
 
-// equalSlices checks if two slices are equal
-func equalSlices(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i, v := range a {
-		if v != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
-// findMissingItems finds items in a that are not in b
 func findMissingItems(a, b []string) []string {
 	bSet := make(map[string]struct{}, len(b))
 	for _, x := range b {

--- a/tests/schema_test.go
+++ b/tests/schema_test.go
@@ -328,7 +328,7 @@ func (g *GitHubIssueService) CreateOrUpdateIssue(findings []ValidationFinding) e
 		status := boolToStr(f.Required, "required", "optional")
 		itemType := boolToStr(f.IsBlock, "block", "property")
 		if f.SubmoduleName == "" {
-			fmt.Fprintf(&newBody, "`%s`: Missing %s %s `%s` in %s root\n\n",
+			fmt.Fprintf(&newBody, "`%s`: Missing %s %s `%s` in %s\n\n",
 				f.ResourceType, status, itemType, f.Name, cleanPath,
 			)
 		} else {


### PR DESCRIPTION
## Description

This PR fixes warnings regarding a unused function in the markdown tests and it replaced a interface with any in the formatError function

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)