### PR TITLE
feat: add issue to project workflow yml

### DIFF
--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -1,0 +1,37 @@
+name: Add new issues to WAM project board
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.WAM_BOT_APP_ID }}
+          private-key: ${{ secrets.WAM_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Find and add recent issues to project board
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          SINCE=$(date -u -d '61 minutes ago' '+%Y-%m-%dT%H:%M:%SZ')
+
+          mapfile -t ALL_ISSUE_IDS < <(gh api "search/issues?q=org:CloudNationHQ+is:issue+is:open+created:>$SINCE&per_page=100" \
+            --jq '.items[] | select(.repository_url | test("terraform-azure-|terraform-azuread-|terraform-databricks-")) | select(.repository_url | test("terraform-azure-wam") | not) | .node_id')
+
+          for issue_id in "${ALL_ISSUE_IDS[@]}"; do
+            gh api graphql -f query='
+              mutation($project: ID!, $content: ID!) {
+                addProjectV2ItemById(input: {projectId: $project, contentId: $content}) {
+                  item { id }
+                }
+              }' -f project="${{ vars.WAM_PROJECT_ID }}" -f content="$issue_id" &
+          done
+          wait


### PR DESCRIPTION
## Description

**Add workflow: auto-add new issues to WAM project board**

Adds a scheduled GitHub Actions workflow `(.github/workflows/add-issue-to-project.yml)` that automatically picks up newly opened issues across CloudNation's Terraform module repositories and adds them to the TTYE project board.

  How it works:
  - Runs every hour via cron (0 * * * *), and can also be
  triggered manually via workflow_dispatch
  - Authenticates using the WAM Bot GitHub App (WAM_BOT_APP_ID
  / WAM_BOT_PRIVATE_KEY) to generate a scoped token
  - Searches the CloudNationHQ org for open issues created in
  the last 61 minutes (1-minute overlap to avoid missing issues
   on the boundary)
  - Filters to only repositories matching terraform-azure-*,   
  terraform-azuread-*, or terraform-databricks-*, and
  explicitly excludes terraform-azure-wam itself
  - Adds each matching issue to the WAM project board via the  
  GraphQL addProjectV2ItemById mutation, running all mutations 
  in parallel with & / wait
