### PR TITLE
feat(add-issue-to-project): add wam-support/wam-internal repos and switch to daily schedule

### DIFF
--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -2,7 +2,7 @@ name: Add new issues to WAM project board
 
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 jobs:
@@ -26,7 +26,7 @@ jobs:
 
           SEARCH_OUTPUT=$(gh api --paginate \
             "search/issues?q=org:CloudNationHQ+is:issue+is:open+created:>$SINCE&per_page=100" \
-            --jq '.items[] | select(.repository_url | test("terraform-azure-|terraform-azuread-|terraform-databricks-")) | select(.repository_url | test("terraform-azure-wam") | not) | .node_id') \
+            --jq '.items[] | select(.repository_url | test("terraform-azure-|terraform-azuread-|terraform-databricks-|wam-support|wam-internal")) | .node_id') \
             || { echo "::error::Search API call failed."; exit 1; }
 
           mapfile -t ALL_ISSUE_IDS <<< "$SEARCH_OUTPUT"

--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
+    inputs:
+      since:
+        description: 'Backfill from this date (YYYY-MM-DD). Leave empty to use the default 7-day lookback.'
+        required: false
+        default: ''
 
 jobs:
   add-to-project:
@@ -21,7 +26,8 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          SINCE=$(date -u -d '7 days ago' '+%Y-%m-%d')
+          SINCE="${{ inputs.since }}"
+          SINCE="${SINCE:-$(date -u -d '7 days ago' '+%Y-%m-%d')}"
           echo "Looking for issues created since: $SINCE"
 
           SEARCH_OUTPUT=$(gh api --paginate \


### PR DESCRIPTION
## Summary

- Add `wam-support` and `wam-internal` to the repository include pattern in the issue search filter
- Remove the `terraform-azure-wam` exclusion — the repository does not exist
- Change the cron schedule from hourly (`0 * * * *`) to daily (`0 0 * * *`) — the 7-day lookback window makes more frequent runs redundant
- Add a `since` input to `workflow_dispatch` to allow backfilling issues older than 7 days (e.g. pass `2000-01-01` to catch all historical open issues)

## Test plan

- [ ] Trigger via `workflow_dispatch` and verify issues from `wam-support` and `wam-internal` are picked up
- [ ] Confirm no unexpected repos are included
- [ ] Trigger with a custom `since` date to verify backfill works correctly